### PR TITLE
make cacheable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var transform = require('coffee-react-transform');
 module.exports = function(cjsx) {
+  this.cacheable && this.cacheable()
   return transform(cjsx);
 };


### PR DESCRIPTION
it's just a blunt copy-paste code from jsx-loader (https://github.com/petehunt/jsx-loader/blob/master/index.js#L5 ). no more warnings like

```
./src/scripts/components/footer.cjsx 327 {0} [not cacheable] [built]
```
