### PR TITLE
pass webpack options to coffee-react-transform

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var transform = require('coffee-react-transform');
+var loaderUtils = require('loader-utils');
 module.exports = function(cjsx) {
   this.cacheable && this.cacheable();
-  return transform(cjsx);
+  return transform(cjsx, loaderUtils.parseQuery(this.query));
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": "https://github.com/KyleAMathews/cjsx-loader/issues",
   "dependencies": {
-    "coffee-react-transform": "^3.0.0"
+    "coffee-react-transform": "^3.0.0",
+    "loader-utils": "0.2.x"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
So that you can pass queries from webpack, e.g. 'cjsx-loader?literate' through to coffee-react-transform