### PR TITLE
Bump coffee-react-transform dependency to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": "https://github.com/KyleAMathews/cjsx-loader/issues",
   "dependencies": {
-    "coffee-react-transform": "^3.0.0",
+    "coffee-react-transform": "^4.0.0",
     "loader-utils": "0.2.x"
   },
   "keywords": [


### PR DESCRIPTION
Version 4.0.0 of `coffee-react-transform` switches from deprecated `React.__spread` to `Object.assign`.
