### PR TITLE
Use v^4.0.0 of coffee-react-transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bugs": "https://github.com/KyleAMathews/cjsx-loader/issues",
   "dependencies": {
-    "coffee-react-transform": "^3.0.0",
+    "coffee-react-transform": "^4.0.0",
     "loader-utils": "0.2.x"
   },
   "keywords": [


### PR DESCRIPTION
React.__spread is deprecated in React 15, and v^3.0.0 of coffee-react-transform used React.__spread
